### PR TITLE
Update for new location of android support library.

### DIFF
--- a/ExampleApp/build.gradle
+++ b/ExampleApp/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'android'
 
 dependencies {
-    compile 'com.android.support:support-v4:19.1.0'
+    compile 'com.google.android:support-v4:r7'
     compile project(':libraries:Donations')
 }
 

--- a/libraries/Donations/build.gradle
+++ b/libraries/Donations/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'android-library'
 
 dependencies {
-    compile 'com.android.support:support-v4:19.1.0'
+    compile 'com.google.android:support-v4:r7'
 }
 
 android {


### PR DESCRIPTION
Looks like the namespace for this artifact has changed, and build was
failing due to the missing dependency.